### PR TITLE
Feat:社員一覧画面用のコントローラーを追加

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -3,6 +3,7 @@
 // ルート設定をRouterで行う
 require_once __DIR__ . '/core/Router.php';
 require_once __DIR__ . '/contoroller/ShuffleController.php';
+require_once __DIR__ . '/contoroller/EmployeeController.php';
 
 // 初期設定を行う？
 class Application
@@ -37,11 +38,12 @@ class Application
 
     // 配列で
     private function registerRoutes()
-
     {
         return [
             '/' => ['controller' => 'shuffle', 'action' => 'index'],
-            '/shuffle' => ['controller' => 'shuffle', 'action' => 'create']
+            '/shuffle' => ['controller' => 'shuffle', 'action' => 'create'],
+            '/employee' => ['controller' => 'employee', 'action' => 'index'],
+            '/employee/create' => ['controller' => 'employee', 'action' => 'create']
         ];
     }
 

--- a/src/contoroller/EmployeeController.php
+++ b/src/contoroller/EmployeeController.php
@@ -1,0 +1,79 @@
+<?php
+
+require_once __DIR__ . '/../core/Controller.php';
+
+class EmployeeController extends Controller
+{
+    public function index()
+    {
+        $errors = [];
+
+        // DBに接続
+        $mysqli = new mysqli('db', 'test_user', 'pass', 'test_database');
+        // 接続エラーのバリデーション
+        // connect_error 接続エラーの内容（文字列）を返すプロパティ
+        if ($mysqli->connect_error) {
+          // PHP組み込み例外クラス:「実行時に予期せぬ問題が発生」を表示
+            throw new RuntimeException('mysqli接続エラー: ' . $mysqli->connect_error);
+        }
+
+        $result = $mysqli->query('SELECT name FROM employees;');
+        $employees = $result->fetch_all(MYSQLI_ASSOC);
+
+
+
+        $mysqli->close();
+
+        // データ追加後、即座に一覧に反映。また、POSTの重複によるデータの二重登録を防止
+        // 登録ボタン推してもリロードはされない。
+        include __DIR__ . '/../views/employee.php';
+
+    }
+
+
+
+    public function create()
+    {
+
+        $errors = [];
+
+        // DBに接続
+        $mysqli = new mysqli('db', 'test_user', 'pass', 'test_database');
+        // 接続エラーのバリデーション
+        // connect_error 接続エラーの内容（文字列）を返すプロパティ
+        if ($mysqli->connect_error) {
+        // PHP組み込み例外クラス:「実行時に予期せぬ問題が発生」を表示
+            throw new RuntimeException('mysqli接続エラー: ' . $mysqli->connect_error);
+        }
+
+        $result = $mysqli->query('SELECT name FROM employees;');
+        $employees = $result->fetch_all(MYSQLI_ASSOC);
+
+
+        // $_POSTは配列なのでキー名指定が必用　指定が無いと常にfalseになる
+        if ($_POST['name'] === '') {
+            $errors['name'] = '社員名を入力してください';
+            // $_POSTは配列なのでキー名指定が必用
+        } elseif (mb_strlen($_POST['name']) > 100) {
+            $errors['name'] = '100文字以内で入力してください';
+        }
+
+        // $errorsが無ければデータを登録
+        if (!count($errors)) {
+            $name = $_POST['name'];
+            $addData = 'INSERT INTO employees (name) VALUES (?)';
+
+            $stmt = $mysqli->prepare($addData);
+            $stmt->bind_param("s", $name);
+            $stmt->execute();
+            $stmt->close();
+            header('Location: /employee');
+
+            $mysqli->close();
+
+            // データ追加後、即座に一覧に反映。また、POSTの重複によるデータの二重登録を防止
+            // 登録ボタン推してもリロードはされない。
+            include __DIR__ . '/../views/employee.php';
+        }
+    }
+}

--- a/src/contoroller/ShuffleController.php
+++ b/src/contoroller/ShuffleController.php
@@ -1,14 +1,10 @@
 <?php
 
-class ShuffleController
-{
-    // $actionに'index'
-    public function run($action)
-    {
-        $this->$action();
-    }
+require_once __DIR__ . '/../core/Controller.php';
 
-    private function index()
+class ShuffleController extends Controller
+{
+    public function index()
     {
         $groups = [];
 
@@ -26,9 +22,8 @@ class ShuffleController
     }
 
 
-    private function create()
+    public function create()
     {
-
         $groups = [];
 
         // DBに接続
@@ -58,7 +53,5 @@ class ShuffleController
         }
 
         include __DIR__ . '/../views/index.php';
-
     }
-
 }

--- a/src/core/Controller.php
+++ b/src/core/Controller.php
@@ -1,0 +1,10 @@
+<?php
+
+class Controller
+{
+    // $actionに'index'
+    public function run($action)
+    {
+        $this->$action();
+    }
+}

--- a/src/views/employee.php
+++ b/src/views/employee.php
@@ -8,7 +8,7 @@
 
 <body>
     <div>
-        <a href="./index.php">シャッフルランチサービス</a>
+        <a href="/shuffle">シャッフルランチサービス</a>
     </div>
 
     <?php if ($errors): ?>
@@ -21,7 +21,7 @@
         </ul>
     <?php endif; ?>
 
-    <form action="./employees.php" method="post">
+    <form action="employee/create" method="post">
         <label for="name">社員名</label>
         <input type="text" name="name">
         <!-- <input type="submit" value="登録する">の書き方もありだが、シンプルな実装なので装飾出来る下記が主流-->

--- a/src/views/index.php
+++ b/src/views/index.php
@@ -8,9 +8,9 @@
 
 <body>
     <h1>
-        <a href="./index.php">シャッフルランチ</a>
+        <a href="/employee">シャッフルランチ</a>
     </h1>
-    <a href="./employees.php">社員を登録する</a>
+    <a href="employee">社員を登録する</a>
 
     <form action="shuffle" method="post">
         <button type="submit">シャッフルする</button>


### PR DESCRIPTION
### 概要
- コントローラー共通処理（runメソッド）を抽出し、Controller基底クラスを追加
- 社員一覧画面用のEmployeeControllerを新規作成し、ビューとの接続を実装

### 変更点
- `src/core/Controller.php` を追加し、共通run処理を実装
- `src/controller/EmployeeController.php` を追加
- ルーティングに `/employee` と `/employee/create` を追加
- `views/index.php` などからのリンクとビュー遷移先を修正
