### PR TITLE
Feat:未定義ルートへのアクセス時に404ページを表示する処理を追加

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -54,7 +54,7 @@ class Application
         return [
             '/' => ['controller' => 'shuffle', 'action' => 'index'],
             '/shuffle' => ['controller' => 'shuffle', 'action' => 'create'],
-            '/employee' => ['controller' => 'employee', 'action' => 'idex'],
+            '/employee' => ['controller' => 'employee', 'action' => 'index'],
             '/employee/create' => ['controller' => 'employee', 'action' => 'create']
         ];
     }

--- a/src/Application.php
+++ b/src/Application.php
@@ -2,6 +2,7 @@
 
 // ルート設定をRouterで行う
 require_once __DIR__ . '/core/Router.php';
+require_once __DIR__ . '/core/HttpNotFoundException.php';
 require_once __DIR__ . '/contoroller/ShuffleController.php';
 require_once __DIR__ . '/contoroller/EmployeeController.php';
 
@@ -22,16 +23,27 @@ class Application
         // 名前解決　resolveの引数であるパスと、constで設定したコントローラー（アクション？）を紐づけ
             // 引数：パス
             // 返り値 $params = [controller => 〇〇, action => 〇〇];
-        $params = $this->router->resolve($this->getPathInfo());
-        $controller = $params['controller'];
-        $action = $params['action'];
-        $this->runAction($controller, $action);
+        try {
+            $params = $this->router->resolve($this->getPathInfo());
+            if (!$params) {
+                throw new HttpNotFoundException();
+            };
+            $controller = $params['controller'];
+            $action = $params['action'];
+            $this->runAction($controller, $action);
+        } catch (HttpNotFoundException) {
+            $this->render404Page();
+        }
+
     }
 
     // controllerの動的生成と実行
     private function runAction($controllerName, $action)
     {
         $controllerClass = ucfirst($controllerName) . 'Controller';
+        if (!class_exists($controllerClass)) {
+            throw new HttpNotFoundException();
+        }
         $controller = new $controllerClass();
         $controller->run($action);
     }
@@ -42,7 +54,7 @@ class Application
         return [
             '/' => ['controller' => 'shuffle', 'action' => 'index'],
             '/shuffle' => ['controller' => 'shuffle', 'action' => 'create'],
-            '/employee' => ['controller' => 'employee', 'action' => 'index'],
+            '/employee' => ['controller' => 'employee', 'action' => 'idex'],
             '/employee/create' => ['controller' => 'employee', 'action' => 'create']
         ];
     }
@@ -51,5 +63,29 @@ class Application
     private function getPathInfo()
     {
         return $_SERVER['REQUEST_URI'];
+    }
+
+    private function render404Page()
+    {
+        //HTTPレスポンスのステータスコードを「404 Not Found」に設定するためのPHPコードです。
+        header('HTTP/1.1 404 Page Not Found');
+        $content = <<<EOF
+
+        <!DOCTYPE html>
+        <html lang="ja">
+        <head>
+        <meta charset="UTF-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        <title>404</title>
+        </head>
+
+        <body>
+            <h1>
+                404 Page Not Found.
+            </h1>
+        </body>
+        </html>
+EOF;
+        echo $content;
     }
 }

--- a/src/core/Controller.php
+++ b/src/core/Controller.php
@@ -5,6 +5,11 @@ class Controller
     // $actionに'index'
     public function run($action)
     {
+        // $thisクラスにおける$actionメソッドの有無を確認
+        if (!method_exists($this, $action)) {
+            throw new HttpNotFoundException();
+        }
+
         $this->$action();
     }
 }

--- a/src/core/HttpNotFoundException.php
+++ b/src/core/HttpNotFoundException.php
@@ -1,0 +1,6 @@
+<?php
+
+//エラー内容を区別する為にExceptionを継承したクラスを作成。メソッドは不要（らしい）
+class HttpNotFoundException extends Exception
+{
+};


### PR DESCRIPTION
- エラー種別を明確にする為、専用例外クラス`HttpNotFoundException`を作成
- 404エラーをtry-catchで補足
- HTTPステータスコード404を返す処理を実装
- `NotFound`を表示するページを表示